### PR TITLE
Only drink potions if not fully healed

### DIFF
--- a/actors/actor_combatant.py
+++ b/actors/actor_combatant.py
@@ -39,3 +39,6 @@ class Combatant():
     def dismember(self) -> None:
         self.is_dismembered = True
         self.attack_power = int(self.attack_power * 0.75)
+
+    def is_fully_healed(self) -> bool:
+        return self.health >= self.base_health

--- a/actors/actor_playable.py
+++ b/actors/actor_playable.py
@@ -93,14 +93,16 @@ class PlayableActor(Actor, Inventory, Combatant):
     
 
     def use_potion(self) -> None:
-        if self.potions != 0:
+        if self.potions != 0 and not self.is_fully_healed():
             print(f"{self.name} drinks a potion")
             self.lose_potion(1)
             self.heal(100 + random.randint(-20,20))
             print(f"{self.name} has {self.potions} remaining")
             print(f"{self.name}'s health is now {self.health}", end="\n\n")
-        else:
+        elif self.potions == 0:
             print(f"{self.name} has no remaining potions!")
+        else:
+            print(f"{self.name} is already fully healed!")
 
     def __set_attack_power(self) -> int:
         if self.strength > self.intellect:


### PR DESCRIPTION
This fixes players drinking potions when they are already full health. If this is a feature you don't want, feel free to ignore it.
This also checks if the character is over-healed and won't drink the potion. I don't know if there is any over-healing as I haven't read through all the code yet, but at least it will work if that is/ever becomes a thing.